### PR TITLE
Wait for TaskQueue to be ready before calling wrapper chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,8 +443,28 @@ function callHandlers(handlers, args, method) {
   for (var i = handlers.length - 1; i >= 0; i -= 1) {
     method = handlers[i].bind(null, method, args);
   }
+
+  //make sure the handler chain is not started, before the corresponding
+  //pouchdb instance is fully initialized. Otherwise it might result
+  //in a double calling the augmented methods
+  var promise;
+  if (!args.base.taskqueue.isReady) {
+    promise = new Promise(function (resolve, reject) {
+      args.base.taskqueue.addTask(function (failed) {
+        if (failed) {
+          reject(failed);
+        } else {
+          resolve();
+        }
+      });
+    }).then(function () {
+      return method();
+    });
+  } else {
+    promise = method();
+  }
+
   //start running the chain.
-  var promise = method();
   nodify(promise, callback);
   return promise;
 }


### PR DESCRIPTION
If we are not waiting for the TaskQueue, of the currently active pouchdb instance to be ready, before calling the handler, we might end up calling it twice. Once due to the call from the outside, which initiated the chain and once from the queuing itself, which calls it again, once the pouchdb instance is ready.

This race condition does not always happen, but I found it to happen more often with PouchDB >6.1.1 and the idb-adapter. This is most likely due to optimizations in the setup process of this adapter.